### PR TITLE
Removed misplaced closing bracket of lock-statement

### DIFF
--- a/cs/Subscriptions/Server.HandshakeChanges/Program.cs
+++ b/cs/Subscriptions/Server.HandshakeChanges/Program.cs
@@ -86,7 +86,7 @@ namespace HandshakeChanges
             var server = (OpcServer)state;
 
             while (!producerControl.IsCancellationRequested) {
-                lock (state) {}
+                lock (state) {
                     dataAvailableNode.Value = false;
                     dataAvailableNode.ApplyChanges(server.SystemContext);
 


### PR DESCRIPTION
Additional closing bracket caused a build error.